### PR TITLE
Task/7 modify production deployment path

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -37,5 +37,5 @@ targets:
       catalog: workspace
       schema: prod
     permissions:
-      - service_principal_name: 49a3392f-a177-451d-b696-b004d4979aa6
+      - group_name: workspace_deployers
         level: CAN_MANAGE

--- a/databricks.yml
+++ b/databricks.yml
@@ -32,8 +32,7 @@ targets:
     mode: production
     workspace:
       host: https://dbc-27fa089a-71b7.cloud.databricks.com
-      # We explicitly deploy to /Workspace/Users/49a3392f-a177-451d-b696-b004d4979aa6 to make sure we only have a single copy.
-      root_path: /Workspace/Users/49a3392f-a177-451d-b696-b004d4979aa6/.bundle/${bundle.name}/${bundle.target}
+      root_path: /Workspace/src/.bundle./${bundle.name}/${bundle.target}
     variables:
       catalog: workspace
       schema: prod


### PR DESCRIPTION
## Summary
Change production deployment path and also gave a group called `workspace_deployers` permissions over the production resources instead of the single SP ID string.

## Changes
List the key changes in this PR:
- [x] Changed production deployment path to `src` dir.
- [x] Gave permissions to a specific group instead of the SP to avoid writing the ID directly.

## Checklist
- [x] I have tested my changes locally
- [x] I added/updated documentation if needed
- [x] I added/updated tests
- [x] CI pipeline is passing

## Related Issues
Closes #7 